### PR TITLE
DOM-14710: Don't rsync tools dir to deploy dir

### DIFF
--- a/terraform/templates/launch_ranchhand.sh
+++ b/terraform/templates/launch_ranchhand.sh
@@ -93,7 +93,7 @@ launch_ranchhand() {
   # post-run cleanup and file sync from proxy
   if [[ -n $ssh_proxy_host ]]; then
     ssh $ssh_args $ssh_host_str rm $remote_key_path
-    rsync -ai --rsh="ssh $ssh_args" $ssh_host_str:$workdir/ ./
+    rsync -ai --exclude=ranchhand-output/tools --rsh="ssh $ssh_args" $ssh_host_str:$workdir/ ./
     echo "retrieved output from bastion: $ssh_proxy_host"
   fi
 


### PR DESCRIPTION
We rsync the ranchhand-output to the local directory so we have a local record of the kubeconfig/cluster/etc., but the actual binary tools are a bit irrelevant, particularly WRT to their size and how we're currently using this.

Exclude that tools directory from the return rsync to avoid this.