### PR TITLE
Updates Rancher, RKE and other tools

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,15 +21,16 @@ const runExamples = `
 `
 
 var (
-	nodeIPs       []string
-	sshUser       string
-	sshPort       uint
-	sshKeyPath    string
-	sshTimeout    uint
-	timeout       uint
-	certIPs       []string
-	certDNSNames  []string
-	adminPassword string
+	nodeIPs        []string
+	sshUser        string
+	sshPort        uint
+	sshKeyPath     string
+	sshTimeout     uint
+	timeout        uint
+	certIPs        []string
+	certDNSNames   []string
+	adminPassword  string
+	upgradeRancher bool
 
 	runCmd = &cobra.Command{
 		Use:     "run",
@@ -43,11 +44,12 @@ var (
 					KeyPath:           sshKeyPath,
 					ConnectionTimeout: sshTimeout,
 				},
-				Nodes:         ranchhand.BuildNodes(nodeIPs),
-				Timeout:       time.Duration(timeout) * time.Second,
-				CertIPs:       certIPs,
-				CertDNSNames:  certDNSNames,
-				AdminPassword: adminPassword,
+				Nodes:          ranchhand.BuildNodes(nodeIPs),
+				Timeout:        time.Duration(timeout) * time.Second,
+				CertIPs:        certIPs,
+				CertDNSNames:   certDNSNames,
+				AdminPassword:  adminPassword,
+				UpgradeRancher: upgradeRancher,
 			}
 
 			if err := ranchhand.Run(&cfg); err != nil {
@@ -69,6 +71,7 @@ func init() {
 	runCmd.Flags().StringSliceVarP(&certDNSNames, "cert-dns-names", "d", []string{"rancher.example.org"}, "list of dns names in ca cert (comma-delimited, first is CN)")
 	runCmd.Flags().StringVarP(&adminPassword, "admin-password", "r", "", "change default admin password")
 	runCmd.Flags().UintVarP(&timeout, "timeout", "t", 300, "total time to wait (in secs) for host processing to complete")
+	runCmd.Flags().BoolVar(&upgradeRancher, "upgrade-rancher", false, "Upgrade Rancher version")
 
 	runCmd.MarkFlagRequired("node-ips")
 	runCmd.MarkFlagRequired("ssh-key-path")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,16 +21,18 @@ const runExamples = `
 `
 
 var (
-	nodeIPs        []string
-	sshUser        string
-	sshPort        uint
-	sshKeyPath     string
-	sshTimeout     uint
-	timeout        uint
-	certIPs        []string
-	certDNSNames   []string
-	adminPassword  string
-	upgradeRancher bool
+	nodeIPs           []string
+	sshUser           string
+	sshPort           uint
+	sshKeyPath        string
+	sshTimeout        uint
+	timeout           uint
+	certIPs           []string
+	certDNSNames      []string
+	adminPassword     string
+	upgradeRancher    bool
+	upgradeKubernetes bool
+	upgradeAll        bool
 
 	runCmd = &cobra.Command{
 		Use:     "run",
@@ -44,12 +46,18 @@ var (
 					KeyPath:           sshKeyPath,
 					ConnectionTimeout: sshTimeout,
 				},
-				Nodes:          ranchhand.BuildNodes(nodeIPs),
-				Timeout:        time.Duration(timeout) * time.Second,
-				CertIPs:        certIPs,
-				CertDNSNames:   certDNSNames,
-				AdminPassword:  adminPassword,
-				UpgradeRancher: upgradeRancher,
+				Nodes:             ranchhand.BuildNodes(nodeIPs),
+				Timeout:           time.Duration(timeout) * time.Second,
+				CertIPs:           certIPs,
+				CertDNSNames:      certDNSNames,
+				AdminPassword:     adminPassword,
+				UpgradeRancher:    upgradeRancher,
+				UpgradeKubernetes: upgradeKubernetes,
+			}
+
+			if upgradeAll {
+				cfg.UpgradeRancher = true
+				cfg.UpgradeKubernetes = true
 			}
 
 			if err := ranchhand.Run(&cfg); err != nil {
@@ -71,7 +79,9 @@ func init() {
 	runCmd.Flags().StringSliceVarP(&certDNSNames, "cert-dns-names", "d", []string{"rancher.example.org"}, "list of dns names in ca cert (comma-delimited, first is CN)")
 	runCmd.Flags().StringVarP(&adminPassword, "admin-password", "r", "", "change default admin password")
 	runCmd.Flags().UintVarP(&timeout, "timeout", "t", 300, "total time to wait (in secs) for host processing to complete")
-	runCmd.Flags().BoolVar(&upgradeRancher, "upgrade-rancher", false, "Upgrade Rancher version")
+	runCmd.Flags().BoolVar(&upgradeRancher, "upgrade-rancher", false, "Upgrade Rancher version via Helm")
+	runCmd.Flags().BoolVar(&upgradeKubernetes, "upgrade-k8s", false, "Upgrade Kubernetes state via RKE")
+	runCmd.Flags().BoolVar(&upgradeAll, "upgrade", false, "Upgrade both Rancher and Kubernetes")
 
 	runCmd.MarkFlagRequired("node-ips")
 	runCmd.MarkFlagRequired("ssh-key-path")

--- a/pkg/ranchhand/rancher.go
+++ b/pkg/ranchhand/rancher.go
@@ -39,7 +39,7 @@ var (
 			helm.ReleaseInfo{
 				Name:      "rancher",
 				Namespace: rancherNamespace,
-				Version:   "2.2.4",
+				Version:   "2.2.5",
 				SetValues: map[string]string{
 					"tls":            "external",
 					"privateCA":      "true",

--- a/pkg/ranchhand/rancher.go
+++ b/pkg/ranchhand/rancher.go
@@ -29,17 +29,21 @@ var (
 		{
 			"stable/cert-manager",
 			helm.ReleaseInfo{
-				Name:      "cert-manager",
-				Namespace: "kube-system",
-				Version:   "v0.5.2",
+				Name:        "cert-manager",
+				Namespace:   "kube-system",
+				Version:     "v0.5.2",
+				Description: "Installed by Ranchhand",
+				Wait:        true,
 			},
 		},
 		{
 			"rancher-stable/rancher",
 			helm.ReleaseInfo{
-				Name:      "rancher",
-				Namespace: rancherNamespace,
-				Version:   "2.2.5",
+				Name:        "rancher",
+				Namespace:   rancherNamespace,
+				Version:     "2.2.5",
+				Description: "Installed by Ranchhand",
+				Wait:        true,
 				SetValues: map[string]string{
 					"tls":            "external",
 					"privateCA":      "true",
@@ -89,7 +93,7 @@ func createRancherSecret(certPEM []byte, kubeConfig string) error {
 	return nil
 }
 
-func installRancher(h helm.Helm, host string) error {
+func installRancher(h helm.Helm, host string, upgrade bool) error {
 	exists, err := h.IsRepo(rancherRepo.Name)
 	if err != nil {
 		return err
@@ -107,13 +111,18 @@ func installRancher(h helm.Helm, host string) error {
 		if err != nil {
 			return err
 		}
-		if !installed {
-			rlsInfo.Description = "Installed by RanchHand"
-			rlsInfo.Wait = true
 
-			if err := h.InstallRelease(rls.Chart, &rlsInfo); err != nil {
-				return err
-			}
+		switch {
+		case !installed:
+			err = h.InstallRelease(rls.Chart, &rlsInfo)
+		case upgrade:
+			err = h.UpgradeRelease(rls.Chart, &rlsInfo)
+		default:
+			log.Infof("%s is installed (upgrade not requested)", rlsInfo.Name)
+		}
+
+		if err != nil {
+			return err
 		}
 	}
 	return rancher.Ping(host)

--- a/pkg/ranchhand/rke.go
+++ b/pkg/ranchhand/rke.go
@@ -43,7 +43,6 @@ services:
     extra_args:
       anonymous-auth: "false"
       profiling: "false"
-      repair-malformed-updates: "false"
       service-account-lookup: "true"
       enable-admission-plugins: "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds,AlwaysPullImages,DenyEscalatingExec,NodeRestriction,EventRateLimit,PodSecurityPolicy"
       admission-control-config-file: "{{ .AdmissionControlConfigFile }}"

--- a/pkg/ranchhand/run.go
+++ b/pkg/ranchhand/run.go
@@ -32,7 +32,8 @@ type Config struct {
 	CertDNSNames  []string
 	AdminPassword string
 
-	UpgradeRancher bool
+	UpgradeRancher    bool
+	UpgradeKubernetes bool
 }
 
 func Run(cfg *Config) error {

--- a/pkg/ranchhand/run.go
+++ b/pkg/ranchhand/run.go
@@ -31,6 +31,8 @@ type Config struct {
 	CertIPs       []string
 	CertDNSNames  []string
 	AdminPassword string
+
+	UpgradeRancher bool
 }
 
 func Run(cfg *Config) error {
@@ -80,7 +82,7 @@ func Run(cfg *Config) error {
 	nodeIP := cfg.Nodes[0].PublicIP
 
 	log.Info("deploying rancher application")
-	if err := installRancher(hClient, nodeIP); err != nil {
+	if err := installRancher(hClient, nodeIP, cfg.UpgradeRancher); err != nil {
 		return err
 	}
 

--- a/pkg/ranchhand/tools.go
+++ b/pkg/ranchhand/tools.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	PlatformToolVersions = map[string]string{
-		"kubectl": "v1.14.3",
-		"helm":    "v2.14.1",
-		"rke":     "v0.2.4",
+		"kubectl": "v1.15.0",
+		"helm":    "v2.14.2",
+		"rke":     "v0.2.5",
 	}
 
 	PlatformToolURLs = map[string]RequiredToolURLs{

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -4,19 +4,19 @@
 VAGRANT_BOXES = {
   ubuntu_bionic: {
     box: "ubuntu/bionic64",
-    box_version: "20190513.0.0"
+    box_version: "20190708.0.0"
   },
   ubuntu_xenial: {
     box: "ubuntu/xenial64",
-    box_version: "20190308.0.0"
+    box_version: "20190708.0.0"
   },
   centos: {
     box: "centos/7",
-    box_version: "1902.01",
+    box_version: "1905.01",
   },
   rhel: {
     box: "generic/rhel7",
-    box_version: "1.9.10",
+    box_version: "1.9.18",
   }
 }
 
@@ -45,7 +45,9 @@ Vagrant.configure("2") do |config|
       c.vm.provider :virtualbox do |vb|
         vb.cpus = 2
         vb.memory = "4096"
-        vb.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
+
+        # NOTE: VirtualBox v6.x is SLOW with the following setting
+        # vb.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
       end
     end
   end


### PR DESCRIPTION
## Summary

Upgrade toolset and added the ability for users to selectively upgrade Rancher, K8s or both on existing HA Rancher clusters.

## Changes
- [X] update Helm (v2.14.2)
- [X] update Kubectl (v1.15.0)
- [X] update RKE (v0.2.5)
- [X] update Vagrant test boxes
- [x] adds Rancher upgrade option
- [x] adds K8s upgrade option