### PR TITLE
switch to random_password and remove '-'

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,9 +19,12 @@ locals {
   ip_addresses = "${join(",", var.node_ips)}"
 }
 
-resource "random_string" "password" {
-  count = "${var.admin_password == "" ? 1 : 0}"
+resource "random_password" "password" {
+  count  = "${var.admin_password == "" ? 1 : 0}"
   length = 20
+
+  # The default EXCEPT '-' because it can trigger CLI arguments
+  override_special = "'!@#$%&*()_=+[]{}<>:?"
 }
 
 data "template_file" "launcher" {
@@ -58,7 +61,7 @@ resource "null_resource" "provisioner" {
     working_dir = "${var.working_dir}"
 
     environment = {
-      RANCHER_PASSWORD = "${var.admin_password == "" ? join("", random_string.password.*.result) : var.admin_password}"
+      RANCHER_PASSWORD = "${var.admin_password == "" ? join("", random_password.password.*.result) : var.admin_password}"
     }
   }
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -4,5 +4,5 @@ output "cluster_provisioned" {
 
 output "admin_password" {
   description = "Generated Rancher admin user password"
-  value       = "${var.admin_password == "" ? join("", random_string.password.*.result) : var.admin_password}"
+  value       = "${var.admin_password == "" ? join("", random_password.password.*.result) : var.admin_password}"
 }


### PR DESCRIPTION
The '-' character can trigger CLI commands, e.g.:
```
... --rancher-password '-ABC123$' # => expected one argument
```