### PR TITLE
DOM-17465: Install docker directly from mirror

### DIFF
--- a/pkg/ranchhand/processhosts.go
+++ b/pkg/ranchhand/processhosts.go
@@ -54,7 +54,7 @@ var (
 		"rhel": {
 			"sudo yum install -y yum-utils device-mapper-persistent-data lvm2",
 			"export REPO_ROOT=\"https://mirrors.domino.tech/artifacts/docker\"",
-			"yum install -y $REPO_ROOT/docker-ce-18.09.6-3.el7.x86_64.rpm $REPO_ROOT/docker-ce-cli-18.09.6-3.el7.x86_64.rpm $REPO_ROOT/containerd.io-1.2.10-3.2.el7.x86_64.rpm $REPO_ROOT/container-selinux-2.107-3.el7.noarch.rpm",
+			"sudo yum install -y $REPO_ROOT/docker-ce-18.09.6-3.el7.x86_64.rpm $REPO_ROOT/docker-ce-cli-18.09.6-3.el7.x86_64.rpm $REPO_ROOT/containerd.io-1.2.10-3.2.el7.x86_64.rpm $REPO_ROOT/container-selinux-2.107-3.el7.noarch.rpm",
 			"sudo systemctl enable docker",
 			"sudo systemctl start docker",
 		},

--- a/pkg/ranchhand/processhosts.go
+++ b/pkg/ranchhand/processhosts.go
@@ -52,10 +52,9 @@ var (
 			"sudo systemctl start docker",
 		},
 		"rhel": {
-			"sudo subscription-manager repos --enable rhel-7-server-extras-rpms || echo 'Error enabling rhel extras repo, continuing...'",
 			"sudo yum install -y yum-utils device-mapper-persistent-data lvm2",
-			"sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
-			"sudo yum install -y docker-ce-18.09.6-3.el7 docker-ce-cli-18.09.6-3.el7 containerd.io",
+			"export REPO_ROOT=\"https://mirrors.domino.tech/artifacts/docker\"",
+			"yum install -y $REPO_ROOT/docker-ce-18.09.6-3.el7.x86_64.rpm $REPO_ROOT/docker-ce-cli-18.09.6-3.el7.x86_64.rpm $REPO_ROOT/containerd.io-1.2.10-3.2.el7.x86_64.rpm $REPO_ROOT/container-selinux-2.107-3.el7.noarch.rpm",
 			"sudo systemctl enable docker",
 			"sudo systemctl start docker",
 		},


### PR DESCRIPTION
This is just for the legacy ranchhand installer when used by v12 deployers on RHEL in AWS.