### PR TITLE
Ansible SSH Timeout: Increase Configurable Timeouts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,9 @@ resource "null_resource" "ansible_playbook" {
 
     working_dir = "${path.module}"
     environment = {
-      RANCHER_PASSWORD = var.admin_password == "" ? join("", random_password.password.*.result) : var.admin_password
+      ANSIBLE_SSH_RETRIES = var.ansible_ssh_retries
+      ANSIBLE_TIMEOUT     = var.ansible_ssh_timeout
+      RANCHER_PASSWORD    = var.admin_password == "" ? join("", random_password.password.*.result) : var.admin_password
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,14 @@ variable "node_ips" {
 #------------------------------------------------------------------------------
 # OPTIONAL
 #------------------------------------------------------------------------------
+variable "ansible_ssh_retries" {
+  default = 5
+}
+
+variable "ansible_ssh_timeout" {
+  default = 30
+}
+
 variable "working_dir" {
   description = "Directory where ranchhand should be executed. Defaults to the current working directory."
   default     = ""


### PR DESCRIPTION
[DOM-17488](https://dominodatalab.atlassian.net/browse/DOM-17488)

Increase timeout from 10 seconds to 30 seconds and retries from 0 to 5.

- https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_TIMEOUT
- https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-ssh-retries