### PR TITLE
fix Terraform v0.12 deprecation warnings for 0.11 syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,13 +85,13 @@ jobs:
       - checkout
       - install_terraform
       - run:
+          name: Terraform fmt
+          command: terraform fmt -check
+      - run:
           name: Terraform validate
           command: |
             terraform init
             terraform validate
-      - run:
-          name: Terraform fmt
-          command: terraform fmt -check
       - install_ansible
       - run:
           name: Check Ansible Syntax

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,11 @@ jobs:
       - checkout
       - install_terraform
       - run:
+          name: Terraform validate
+          command: |
+            terraform init
+            terraform validate
+      - run:
           name: Terraform fmt
           command: terraform fmt -check
       - install_ansible

--- a/ansible/roles/rancher/tasks/cert-manager.yml
+++ b/ansible/roles/rancher/tasks/cert-manager.yml
@@ -6,7 +6,7 @@
   changed_when: false
   register: crd
 
-- name: Copy cert-manager Custom Resoure Definintion
+- name: Copy cert-manager Custom Resoure Definition
   become: true
   copy:
     src: "cert-manager-crds-{{ cert_manager_version }}.yaml"

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "null_resource" "ansible_playbook" {
         ansible/prod.yml --diff
     EOF
 
-    working_dir = "${path.module}"
+    working_dir = path.module
     environment = {
       RANCHER_PASSWORD = var.admin_password == "" ? join("", random_password.password.*.result) : var.admin_password
     }
@@ -35,6 +35,6 @@ resource "null_resource" "ansible_playbook" {
 
   provisioner "local-exec" {
     command     = "cp ansible.${self.id}/kube_config_rancher-cluster.yml kube_config_rancher-cluster.yml"
-    working_dir = "${var.working_dir}"
+    working_dir = var.working_dir
   }
 }


### PR DESCRIPTION
```
Warning: Interpolation-only expressions are deprecated

  on [...]terraform/modules/rancher_cluster.ranchhand/main.tf line 40, in resource "null_resource" "ansible_playbook":
  40:     working_dir = "${var.working_dir}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```