### PR TITLE
self-signed cert: add extended x509v3 attributes

### DIFF
--- a/ansible/roles/rke/tasks/ssl-certificates.yml
+++ b/ansible/roles/rke/tasks/ssl-certificates.yml
@@ -15,6 +15,11 @@
     subject_alt_name: "{{ cert_names }}"
     organization_name: Domino Data Lab, Inc.
     organizational_unit_name: Platform Engineering
+    key_usage: ["Digital Signature", "Certificate Sign"]
+    key_usage_critical: yes
+    extended_key_usage: ["TLS Web Server Authentication", "TLS Web Client Authentication"]
+    basic_constraints: "CA:TRUE"
+    basic_constraints_critical: yes
 
 - name: Generate a Self Signed OpenSSL Certificate
   local_action:


### PR DESCRIPTION
Was not able to connect to the cluster for k8s operations and curl was receiving a "SEC_ERROR_CA_CERT_INVALID".

This used to be in ranchhand and was missing from the latest version:
https://github.com/dominodatalab/ranchhand/blob/02d2c15f1ccbba9973dcefc5b4e6ee5d95372cf0/pkg/x509/certificate.go#L29-L30

The best explanation I can find is for why it's necessary is https://superuser.com/questions/1164464/firefox-reports-sec-error-ca-cert-invalid-after-changing-web-site-certificate. I definitely tested azure at some point... though I may have tested an older ranchhand?!