### PR TITLE
Set ssh known_hosts file to /dev/null

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   ip_addresses      = join(",", var.node_ips)
-  ansible_ssh_proxy = var.ssh_proxy_host == "" ? "" : format("-o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -i %s -o StrictHostKeyChecking=no -W %%h:%%p -q %s@%s\"", var.ssh_key_path, var.ssh_proxy_user, var.ssh_proxy_host)
+  ansible_ssh_proxy = var.ssh_proxy_host == "" ? "" : format("-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand=\"ssh -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %%h:%%p -q %s@%s\"", var.ssh_key_path, var.ssh_proxy_user, var.ssh_proxy_host)
   cert_dnsnames     = format("DNS:%s", join(",DNS:", var.cert_dnsnames))
   cert_ipaddresses  = length(var.cert_ipaddresses) == 0 ? "" : format(",IP:%s", join(",IP:", var.cert_ipaddresses))
   cert_names        = format("%s%s", local.cert_dnsnames, local.cert_ipaddresses)
@@ -21,7 +21,7 @@ resource "null_resource" "ansible_playbook" {
         -i '${local.ip_addresses},' \
         --private-key=${var.ssh_key_path} \
         --user=${var.ssh_username} \
-        --ssh-common-args='-o StrictHostKeyChecking=no ${local.ansible_ssh_proxy}' \
+        --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${local.ansible_ssh_proxy}' \
         -e 'cert_names=${local.cert_names}' \
         -e 'node_count=${length(var.node_ips)}' \
         -e 'local_output_dir=${var.working_dir}/ansible.${self.id}' \


### PR DESCRIPTION
We have strict host key checking off for the case of a host key mismatch (which is common iterating on cloud deployments), however, this alone allows you to ssh into the bastion, but prevents auth from forwarding, causing very perplexing ssh failures.

Setting hosts file to /dev/null ensures that there are no mismatches to trigger ssh to turn off auth forwarding.