### PR TITLE
Ensure ansible waits until tiller and rancher is up

### DIFF
--- a/ansible/roles/helm/tasks/main.yml
+++ b/ansible/roles/helm/tasks/main.yml
@@ -20,7 +20,3 @@
   command: helm init --service-account tiller --wait
   when: helm_version is failed
   run_once: true
-
-- name: Wait for Tiller to become responsive
-  command: kubectl rollout status --watch deployment tiller-deploy --namespace=kube-system
-  run_once: true

--- a/ansible/roles/helm/tasks/main.yml
+++ b/ansible/roles/helm/tasks/main.yml
@@ -21,6 +21,6 @@
   when: helm_version is failed
   run_once: true
 
-- name: Wait for Tiller to become responsive.
-  wait_for:
-    timeout: 120
+- name: Wait for Tiller to become responsive
+  command: kubectl rollout status --watch deployment tiller-deploy --namespace=kube-system
+  run_once: true

--- a/ansible/roles/helm/tasks/main.yml
+++ b/ansible/roles/helm/tasks/main.yml
@@ -21,3 +21,6 @@
   when: helm_version is failed
   run_once: true
 
+- name: Wait for Tiller to become responsive.
+  wait_for:
+    timeout: 120

--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -21,4 +21,4 @@
 
 - name: Wait for Rancher to be available
   wait_for:
-    timeout: 80
+    timeout: 300

--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -19,6 +19,6 @@
       --wait
   when: "'rancher' not in charts.stdout"
 
-- name: Wait for Rancher to be available.
+- name: Wait for Rancher to be available
   wait_for:
     timeout: 80

--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -18,3 +18,7 @@
       --description='RanchHand Deploy'
       --wait
   when: "'rancher' not in charts.stdout"
+
+- name: Wait for Rancher to be available.
+  wait_for:
+    timeout: 80

--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -20,5 +20,5 @@
   when: "'rancher' not in charts.stdout"
 
 - name: Wait for Rancher to be available
-  wait_for:
-    timeout: 300
+  command: kubectl rollout status --watch deployment rancher --namespace=cattle-system
+  run_once: true


### PR DESCRIPTION
Rancher helm chart doesn't seem to wait even after passing `--wait`. So we explicitly add rollout watch step until the services are up. This is a quick fix until the upstream chart issue is fixed.