### PR TITLE
Allow configuration of Docker daemon-json; explicitly enable log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
       --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' \
       --user=vagrant \
       -e "cert_names=DNS:localhost" \
+      -e "node_count=1" \
       ansible/prod.yml \
       --diff
     ```

--- a/ansible/prod.yml
+++ b/ansible/prod.yml
@@ -14,7 +14,7 @@
       local_action:
         module: file
         path: "{{ local_output_dir | default('/tmp') }}"
-        state: directory 
+        state: directory
 
   roles:
     - system-checks

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart Docker
+  become: yes
+  systemd:
+    state: restarted
+    name: docker

--- a/ansible/roles/docker/handlers/main.yml
+++ b/ansible/roles/docker/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart Docker
+- name: restart docker
   become: yes
   systemd:
     state: restarted

--- a/ansible/roles/docker/tasks/debian.yml
+++ b/ansible/roles/docker/tasks/debian.yml
@@ -32,9 +32,3 @@
       - containerd.io
       - "docker-ce={{ docker_ce_ubuntu_version }}"
     state: present
-
-- name: Add user to docker
-  become: true
-  user:
-    name: "{{ ansible_user_id }}"
-    group: docker

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -21,6 +21,6 @@
     mode: "0644"
   when: docker_daemon_json | default()
   notify:
-    - Restart Docker
+    - restart docker
 
 - meta: flush_handlers

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -10,3 +10,17 @@
   user:
     name: "{{ ansible_user_id }}"
     group: docker
+
+- name: Configure Docker daemon options
+  become: yes
+  template:
+    src: "daemon.json.j2"
+    dest: "/etc/docker/daemon.json"
+    owner: root
+    group: root
+    mode: "0644"
+  when: docker_daemon_json | default()
+  notify:
+    - Restart Docker
+
+- meta: flush_handlers

--- a/ansible/roles/docker/templates/daemon.json.j2
+++ b/ansible/roles/docker/templates/daemon.json.j2
@@ -1,0 +1,3 @@
+{
+{{ docker_daemon_json | indent(2, true) }}
+}

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -4,3 +4,9 @@ docker_ce_yum_version: 18.09.6-3.el7
 containerd_yum_version: 1.2.10-3.2.el7
 container_selinux_yum_version: 2.107-3.el7
 docker_ce_repo_root: https://mirrors.domino.tech/artifacts/docker
+docker_daemon_json: |
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "1g",
+    "max-file": "3"
+  }

--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -5,6 +5,7 @@ containerd_yum_version: 1.2.10-3.2.el7
 container_selinux_yum_version: 2.107-3.el7
 docker_ce_repo_root: https://mirrors.domino.tech/artifacts/docker
 docker_daemon_json: |
+  "live-restore": true,
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "1g",


### PR DESCRIPTION
Docker doesn't currently have log rotation, so it's possible that the logs can cause a node to fall over.

Also opportunistically enabled live-restore and it would allow us to change things like the log-file max on the fly.