### PR TITLE
support a configurable rancher version (and update rke)

### DIFF
--- a/ansible/roles/helm/tasks/main.yml
+++ b/ansible/roles/helm/tasks/main.yml
@@ -17,6 +17,6 @@
   run_once: true
 
 - name: helm Init tiller
-  command: helm init --service-account tiller --wait
+  command: helm init --service-account tiller --wait --upgrade
   when: helm_version is failed
   run_once: true

--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -8,7 +8,7 @@
     helm install rancher-stable/rancher
       --name rancher
       --namespace cattle-system
-      --version {{ rancher__rancher_version }}
+      --version {{ rancher_version | default('2.3.5') }}
       --set replicas={{ node_count }}
       --set antiAffinity=required
       --set tls=external

--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -8,7 +8,7 @@
     helm install rancher-stable/rancher
       --name rancher
       --namespace cattle-system
-      --version {{ rancher_version }}
+      --version {{ rancher__rancher_version }}
       --set replicas={{ node_count }}
       --set antiAffinity=required
       --set tls=external

--- a/ansible/roles/rancher/vars/main.yml
+++ b/ansible/roles/rancher/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 cert_manager_version: v0.9.1
 rancher_password: "{{ lookup('env','RANCHER_PASSWORD') }}"
-rancher_version: 2.3.5
+rancher__rancher_version: "{{ rancher_version | default('2.3.5') }}"

--- a/ansible/roles/rancher/vars/main.yml
+++ b/ansible/roles/rancher/vars/main.yml
@@ -1,4 +1,3 @@
 ---
 cert_manager_version: v0.9.1
 rancher_password: "{{ lookup('env','RANCHER_PASSWORD') }}"
-rancher__rancher_version: "{{ rancher_version | default('2.3.5') }}"

--- a/ansible/roles/rke/tasks/main.yml
+++ b/ansible/roles/rke/tasks/main.yml
@@ -35,7 +35,7 @@
     extra_opts: [--strip-components=1]
   with_items:
     - https://storage.googleapis.com/kubernetes-helm/helm-{{ helm_version }}-linux-amd64.tar.gz
-    - https://github.com/rancher/cli/releases/download/{{ rancher_version }}/rancher-linux-amd64-{{ rancher_version }}.tar.gz
+    - https://github.com/rancher/cli/releases/download/{{ rancher_cli_version }}/rancher-linux-amd64-{{ rancher_cli_version }}.tar.gz
 
 - name: Create executable symbolic links
   become: true

--- a/ansible/roles/rke/templates/rancher-cluster.yml
+++ b/ansible/roles/rke/templates/rancher-cluster.yml
@@ -132,7 +132,7 @@ addons: |
     kind: Group
     name: system:authenticated
   ---
-  apiVersion: extensions/v1beta1
+  apiVersion: policy/v1beta1
   kind: PodSecurityPolicy
   metadata:
     name: restricted

--- a/ansible/roles/rke/vars/main.yml
+++ b/ansible/roles/rke/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 kubectl_version: v1.15.2
-helm_version: v2.14.3
-rancher_version: v2.2.0
+helm_version: v2.16.1
+rancher_cli_version: v2.2.0
 local_output_dir: "/tmp"
-rke_cli_version: v0.3.0
+rke_cli_version: "v{{ rke_version | default('1.0.4') }}"
 tools_dir: "/home/{{ ansible_user_id }}/ranchhand/tools"

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,8 @@ resource "null_resource" "ansible_playbook" {
         --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${local.ansible_ssh_proxy}' \
         -e 'cert_names=${local.cert_names}' \
         -e 'node_count=${length(var.node_ips)}' \
+        -e 'rancher_version=${var.rancher_version}' \
+        -e 'rke_version=${var.rke_version}' \
         -e 'local_output_dir=${var.working_dir}/ansible.${self.id}' \
         ansible/prod.yml --diff
     EOF

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,16 @@ variable "cert_ipaddresses" {
   default     = []
 }
 
+variable "rancher_version" {
+  description = "Rancher version to install into the cluster."
+  default     = ""
+}
+
+variable "rke_version" {
+  description = "RKE version to use to create the underlying Kubernetes cluster."
+  default     = ""
+}
+
 variable "ssh_username" {
   description = "SSH username on the nodes"
   default     = "admin"


### PR DESCRIPTION
Would like to be able to pass a Rancher version from the cloud-specific terraform modules into here, to ease the burden of upgrades. I also updated the RKE version used to lay down the base cluster.