### PR TITLE
default empty strings to correct rancher + rke versions

### DIFF
--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -8,7 +8,7 @@
     helm install rancher-stable/rancher
       --name rancher
       --namespace cattle-system
-      --version {{ rancher_version | default('2.3.5') }}
+      --version {{ rancher_version | default('2.3.5', true) }}
       --set replicas={{ node_count }}
       --set antiAffinity=required
       --set tls=external

--- a/ansible/roles/rke/vars/main.yml
+++ b/ansible/roles/rke/vars/main.yml
@@ -3,5 +3,5 @@ kubectl_version: v1.15.2
 helm_version: v2.16.1
 rancher_cli_version: v2.2.0
 local_output_dir: "/tmp"
-rke_cli_version: "v{{ rke_version | default('1.0.4') }}"
+rke_cli_version: "v{{ rke_version | default('1.0.4', true) }}"
 tools_dir: "/home/{{ ansible_user_id }}/ranchhand/tools"


### PR DESCRIPTION
Missed the optional argument to allow `default` to override empty strings / values.