### PR TITLE
decrease default docker log max-size to 100m

### DIFF
--- a/ansible/roles/docker/vars/main.yml
+++ b/ansible/roles/docker/vars/main.yml
@@ -8,6 +8,6 @@ docker_daemon_json: |
   "live-restore": true,
   "log-driver": "json-file",
   "log-opts": {
-    "max-size": "1g",
+    "max-size": "100m",
     "max-file": "3"
   }


### PR DESCRIPTION
3 x 1g can be quite large when we only allocate ~30GB by default. This
also matches our internal defaults.