### PR TITLE
upgrade to ansible 2.10 & support ansible-galaxy installation of dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ commands:
       - run:
           name: Install Ansible & Dependencies
           command: pip install ansible-base==$ANSIBLE_VERSION
+      - run:
+          name: Install Ansible Packages
+          command: ansible-galaxy install -r ansible/requirements.yml
 
   install_terraform:
     description: Install Terraform
@@ -58,7 +61,6 @@ commands:
     - run:
         name: Execute Ansible Ranchhand
         command: |
-          ansible-galaxy install -r ansible/requirements.yml
           ansible-playbook \
             -i "$(cat private-instance-ip)," \
             --user << parameters.ssh_user >> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
     steps:
       - run:
           name: Install Ansible & Dependencies
-          command: pip install ansible==$ANSIBLE_VERSION
+          command: pip install ansible-base==$ANSIBLE_VERSION
 
   install_terraform:
     description: Install Terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     environment:
       AWSCLI_VERSION: 1.18.103
       TERRAFORM_VERSION: 0.12.29
-      ANSIBLE_VERSION: 2.9.11
+      ANSIBLE_VERSION: 2.10.4
       RANCHER_PASSWORD: thisisanewadminpassword
 
 commands:
@@ -16,7 +16,7 @@ commands:
     steps:
       - run:
           name: Install Ansible & Dependencies
-          command: pip3 install ansible==$ANSIBLE_VERSION
+          command: pip install ansible==$ANSIBLE_VERSION
 
   install_terraform:
     description: Install Terraform
@@ -44,7 +44,7 @@ commands:
     - run:
         name: Install system requirements
         command: |
-          pip3 install awscli==$AWSCLI_VERSION --upgrade
+          pip install awscli==$AWSCLI_VERSION --upgrade
     - run:
         name: Configure test env name
         command: echo 'export INSTANCE_NAME="ranchhand-$CIRCLE_WORKFLOW_JOB_ID-$CIRCLE_BUILD_NUM"' >> $BASH_ENV
@@ -58,6 +58,7 @@ commands:
     - run:
         name: Execute Ansible Ranchhand
         command: |
+          ansible-galaxy install -r ansible/requirements.yml
           ansible-playbook \
             -i "$(cat private-instance-ip)," \
             --user << parameters.ssh_user >> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
       ssh_user:
         type: string
     steps:
-    - run: '[[ $CIRCLE_BRANCH != "steved/ansible-galaxy" && -z $CIRCLE_PULL_REQUEST ]] && circleci step halt || true'
+    - run: '[[ $CIRCLE_BRANCH != "master" && -z $CIRCLE_PULL_REQUEST ]] && circleci step halt || true'
     - checkout
     - install_ansible
     - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ commands:
       ssh_user:
         type: string
     steps:
-    - run: '[[ $CIRCLE_BRANCH != "master" && -z $CIRCLE_PULL_REQUEST ]] && circleci step halt || true'
+    - run: '[[ $CIRCLE_BRANCH != "steved/ansible-galaxy" && -z $CIRCLE_PULL_REQUEST ]] && circleci step halt || true'
     - checkout
     - install_ansible
     - add_ssh_keys:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This tool aims to automate the steps listed in Rancher's official [HA Install][]
      `export RANCHER_PASSWORD=<new password>`
     1.    (required) Configure ansible for proper output:
             `export ANSIBLE_COW_SELECTION=random`
+1. Execute `ansible-galaxy install -r ansible/requirements.yml` to install dependencies
 1. Execute `ansible-playbook -i '1.2.4.5,...,10.20.30.40,' --private-key=~/.ssh/id_rsa --user=ubuntu ansible/prod.yml --diff --check` to perform a dry run of all the changes.
 
 ### Example
@@ -67,6 +68,7 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 1. Use `ansible` to launch a Ranchhand run against your VM(s) and verify your changes.
 
     ```
+    ansible-galaxy install -r ansible/requirements.yml
     ansible-playbook -i '192.168.50.10,' \
       --private-key=~/.ssh/id_rsa \
       --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' \

--- a/ansible/prod.yml
+++ b/ansible/prod.yml
@@ -6,6 +6,7 @@
 
   collections:
     - community.crypto
+    - ansible.posix
 
   vars_prompt:
     - name: cert_names

--- a/ansible/prod.yml
+++ b/ansible/prod.yml
@@ -4,6 +4,9 @@
 ---
 - hosts: all
 
+  collections:
+    - community.crypto
+
   vars_prompt:
     - name: cert_names
       prompt: CA 'comma separated string' of values prefixed by their options. (i.e., email, URI, DNS, RID, IP, dirName, otherName and the ones specific to your CA)

--- a/ansible/prod.yml
+++ b/ansible/prod.yml
@@ -5,8 +5,9 @@
 - hosts: all
 
   collections:
-    - community.crypto
     - ansible.posix
+    - community.crypto
+    - community.general
 
   vars_prompt:
     - name: cert_names

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - community.crypto

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,3 +1,4 @@
 collections:
-  - community.crypto
   - ansible.posix
+  - community.crypto
+  - community.general

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,2 +1,3 @@
 collections:
   - community.crypto
+  - ansible.posix

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ resource "random_password" "password" {
 resource "null_resource" "ansible_playbook" {
   provisioner "local-exec" {
     command = <<-EOF
+      ansible-galaxy install -r ansible/requirements.yml && \
       ansible-playbook \
         -i '${local.ip_addresses},' \
         --private-key=${var.ssh_key_path} \


### PR DESCRIPTION
The `ansible` pip dependency brings in a whopping 300M(!) of dependencies that aren't strictly necessary to run this relatively small repo. Unfortunately, the alternative is to use the minimal `ansible-base` core and download dependencies using their own dependency manager. This implements `galaxy` dependency management.