### PR TITLE
Upgrade ranchhand's helm2 for post-repo world

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ commands:
     - run:
         name: Install system requirements
         command: |
+          sudo apt-get update
           sudo apt-get install -y python3-pip
           pip3 install awscli==$AWSCLI_VERSION --upgrade --user
           echo 'export PATH="$HOME/.local/bin:$PATH"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
         at: .
     - add_ssh_keys:
         fingerprints:
-          - "5a:19:ae:e7:ef:98:4f:2f:68:c3:be:72:62:f9:1d:35"
+          - "a4:d2:38:e5:94:13:7d:6a:2e:c6:52:c6:8f:7f:0e:6b"
     - run:
         name: Install system requirements
         command: |
@@ -46,7 +46,7 @@ commands:
           ./ranchhand run \
             --node-ips $(cat instance-ip) \
             --ssh-user << parameters.ssh_user >> \
-            --ssh-key-path ~/.ssh/id_rsa_5a19aee7ef984f2f68c3be7262f91d35 \
+            --ssh-key-path ~/.ssh/id_rsa_a4d238e594137d6a2ec652c68f7f0e6b \
             --ssh-connect-timeout 180 \
             --admin-password "$3cr3t$auc3"
     - run:

--- a/pkg/helm/wrapper.go
+++ b/pkg/helm/wrapper.go
@@ -63,7 +63,7 @@ func (w *wrapper) Init() error {
 			return err
 		}
 
-		buffer, err := w.helmCommand("init", "--wait", "--skip-repos", "--service-account", TillerServiceAccount).CombinedOutput()
+		buffer, err := w.helmCommand("init", "--wait", "--service-account", TillerServiceAccount).CombinedOutput()
 		if err != nil {
 			output := string(buffer)
 			return errors.Wrapf(err, "helm init failed: %s", output)

--- a/pkg/helm/wrapper.go
+++ b/pkg/helm/wrapper.go
@@ -63,7 +63,7 @@ func (w *wrapper) Init() error {
 			return err
 		}
 
-		buffer, err := w.helmCommand("init", "--wait", "--service-account", TillerServiceAccount).CombinedOutput()
+		buffer, err := w.helmCommand("init", "--wait", "--skip-repos", "--service-account", TillerServiceAccount).CombinedOutput()
 		if err != nil {
 			output := string(buffer)
 			return errors.Wrapf(err, "helm init failed: %s", output)

--- a/pkg/ranchhand/tools.go
+++ b/pkg/ranchhand/tools.go
@@ -15,7 +15,7 @@ import (
 var (
 	PlatformToolVersions = map[string]string{
 		"kubectl": "v1.15.2",
-		"helm":    "v2.14.3",
+		"helm":    "v2.17.0",
 		"rke":     "v0.2.7",
 	}
 


### PR DESCRIPTION
Update to newest helm so we can get updated repo url.

We'd added `--skip-repos`  for the legacy helm2 support in the current agent, and I made some assumptions from that decision, but ultimately decided against that for now:

a.) the chart repo url in the newest version still works
b.) we need it because we're getting cert-manager from there

Might not work forever, so if we need to be able to do these deploys for a while longer if that breaks, we'll probably need to include the cert-manager chart. Might be worth downloading it and putting it on the mirror or something, but for now... just getting this working at all.

Also fix tests, for some reason.