### PR TITLE
Revert kube-state-metrics labels

### DIFF
--- a/ansible/roles/newrelic/tasks/newrelic.yml
+++ b/ansible/roles/newrelic/tasks/newrelic.yml
@@ -46,8 +46,6 @@
       --set securityContext.enabled=true
       --set securityContext.runAsUser=65534
       --set securityContext.fsGroup=65534
-      --set service.labels.k8s-app=kube-state-metrics
-      --set-string  service.annotations."prometheus\.io/scrape"=true
   when: not (charts.json | json_query("[?name == \"kube-state-metrics\"]"))
 
 - name: Install Newrelic Services


### PR DESCRIPTION
I added two labels to `kube-state-metrics` service thinking `newrelic-open-metrics` should be able to scrape metrics from it. But `newrelic-open-metrics` is used to scrape metrics from various other services like `nginx`, `mongodb` etc., whereas `newrelic-infrastructure` is used to scrape metrics from `kube-state-metrics` for infra level metrics. Hence reverting it to avoid redundancy. 