### PR TITLE
removes addLocal flag for Rancher version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This tool aims to automate the steps listed in Rancher's official [HA Install][]
 
 ## Usage
 
+1. Ensure that the Rancher version is >= 2.5. 
 1. Download the [latest release][] from GitHub.
 1. [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) (version >=2.8) locally
 1.  (optional) To update the Rancher default password, set the `RANCHER_PASSWORD` environment variable:

--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -12,7 +12,7 @@
       --set antiAffinity=required
       --set tls=external
       --set privateCA=true
-      --set addLocal=false
+      --set restrictedAdmin=true
       --set auditLog.level=1
       --description='RanchHand Deploy'
       --wait

--- a/ansible/roles/rancher/vars/main.yml
+++ b/ansible/roles/rancher/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 cert_manager_version: v0.9.1
 rancher_password: "{{ lookup('env','RANCHER_PASSWORD') }}"
-rancher_version: 2.3.6
+rancher_version: 2.5.6


### PR DESCRIPTION
To upgrade to a newer Rancher version >= 2.5.x, the addLocal flag must be removed as Rancher will not start with it in `false`. This PR is to remove the flag, and add `restrictedAdmin` in order for us to upgrade Rancher to latest (2.5.6).
https://rancher.com/docs/rancher/v2.x/en/admin-settings/rbac/global-permissions/#upgrading-from-rancher-with-a-hidden-local-cluster

The `restrictedAdmin` flag is now used to continue restricting access to the local cluster. 