### PR TITLE
PLAT-6548 Add a retry to rancher helm install

### DIFF
--- a/ansible/roles/rancher/tasks/rancher.yml
+++ b/ansible/roles/rancher/tasks/rancher.yml
@@ -6,6 +6,7 @@
 - name: Install Rancher
   command: >
     helm upgrade rancher rancher-stable/rancher
+      --install --cleanup-on-fail --wait
       --namespace cattle-system
       --version {{ rancher_version }}
       --set replicas={{ node_count }}
@@ -17,8 +18,11 @@
       --set bootstrapPassword={{ rancher_password }}
       --description='RanchHand Deploy'
       --set rancherImageTag={{ rancher_image_tag }}
-      --wait --install
   when: not (charts.json | json_query("[?name == \"rancher\"]"))
+  register: rancher_install
+  until: rancher_install.rc == 0
+  retries: 3
+  delay: 30
 
 - name: Wait for Rancher to be available
   command: kubectl rollout status --watch deployment rancher --namespace=cattle-system


### PR DESCRIPTION
There are cases where the install fails due to 
```
"Error: Internal error occurred: failed calling webhook
2023-04-24 21:06:43,705 - \"validate.nginx.ingress.kubernetes.io\": failed to call webhook: Post
2023-04-24 21:06:43,705 - \"https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking/v1/ingresses?timeout=10s\":
2023-04-24 21:06:43,705 - dial tcp 10.43.200.174:443: connect: connection refused"]
```
More info:
https://github.com/kubernetes/ingress-nginx/issues/5401
https://github.com/rancher/rancher/issues/33067

We want to retry the `helm upgrade --install` in case of failure.