### PR TITLE
PLAT-7076: Upgrade RKE and friends

### DIFF
--- a/ansible/roles/newrelic/tasks/newrelic.yml
+++ b/ansible/roles/newrelic/tasks/newrelic.yml
@@ -42,7 +42,7 @@
       --set global.licenseKey="{{ newrelic['licensekey'] }}"
       --set global.cluster="rancher"
       --set newrelic-infrastructure.enabled=true
-      --set newrelic-infrastructure.rbac.pspEnabled=true
+      --set newrelic-infrastructure.rbac.pspEnabled=false
       --set newrelic-infrastructure.networkPolicy.create=true
       --set newrelic-infrastructure.resources.limits.memory=128Mi
       --set newrelic-infrastructure.resources.requests.cpu=100m
@@ -53,7 +53,7 @@
       --set newrelic-events.resources.requests.cpu=100m
       --set newrelic-events.resources.requests.memory=128Mi
       --set logging.enabled=true
-      --set newrelic-logging.rbac.pspEnabled=true
+      --set newrelic-logging.rbac.pspEnabled=false
       --set newrelic-logging.networkPolicy.enabled=true
       --set newrelic-logging.resources.limits.memory=256Mi
       --set newrelic-logging.resources.requests.cpu=100m

--- a/ansible/roles/newrelic/tasks/newrelic.yml
+++ b/ansible/roles/newrelic/tasks/newrelic.yml
@@ -43,6 +43,7 @@
       --set global.cluster="rancher"
       --set newrelic-infrastructure.enabled=true
       --set newrelic-infrastructure.rbac.pspEnabled=false
+      --set newrelic-infrastructure.podSecurityPolicy.enabled=false
       --set newrelic-infrastructure.networkPolicy.create=true
       --set newrelic-infrastructure.resources.limits.memory=128Mi
       --set newrelic-infrastructure.resources.requests.cpu=100m
@@ -54,6 +55,7 @@
       --set newrelic-events.resources.requests.memory=128Mi
       --set logging.enabled=true
       --set newrelic-logging.rbac.pspEnabled=false
+      --set newrelic-logging.podSecurityPolicy.enabled=false
       --set newrelic-logging.networkPolicy.enabled=true
       --set newrelic-logging.resources.limits.memory=256Mi
       --set newrelic-logging.resources.requests.cpu=100m

--- a/ansible/roles/rancher/vars/main.yml
+++ b/ansible/roles/rancher/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-cert_manager_version: v1.9.1
+cert_manager_version: v1.12.3
 rancher_password: "{{ lookup('env','RANCHER_PASSWORD') }}"
-rancher_version: 2.6.7
+rancher_version: 2.7.5
 rancher_image_tag: "{{ lookup('env','RANCHER_IMAGE_TAG') }}"

--- a/ansible/roles/rke/templates/rancher-cluster.yml
+++ b/ansible/roles/rke/templates/rancher-cluster.yml
@@ -28,7 +28,7 @@ services:
   kube-controller:
     extra_args:
       profiling: "false"
-      address: "127.0.0.1"
+      bind-address: "127.0.0.1"
       terminated-pod-gc-threshold: "1000"
       feature-gates: RotateKubeletServerCertificate=true
   kubelet:
@@ -46,7 +46,7 @@ services:
   scheduler:
     extra_args:
       profiling: "false"
-      address: "127.0.0.1"
+      bind-address: "127.0.0.1"
 
 ingress:
   provider: nginx
@@ -64,127 +64,7 @@ addons: |
     tls.crt: {{ lookup("file", "{{ local_output_dir }}/dominodatalab.com.crt") | b64encode }}
     tls.key: {{ lookup("file", "{{ local_output_dir }}/dominodatalab.com.pem") | b64encode }}
   ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: default-psp-role
-    namespace: ingress-nginx
-  rules:
-  - apiGroups:
-    - extensions
-    resourceNames:
-    - default-psp
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    name: default-psp-rolebinding
-    namespace: ingress-nginx
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: default-psp-role
-  subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:serviceaccounts
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:authenticated
-  ---
   apiVersion: v1
   kind: Namespace
   metadata:
     name: cattle-system
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: default-psp-role
-    namespace: cattle-system
-  rules:
-  - apiGroups:
-    - extensions
-    resourceNames:
-    - default-psp
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    name: default-psp-rolebinding
-    namespace: cattle-system
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: default-psp-role
-  subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:serviceaccounts
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:authenticated
-  ---
-  apiVersion: policy/v1beta1
-  kind: PodSecurityPolicy
-  metadata:
-    name: restricted
-  spec:
-    requiredDropCapabilities:
-    - NET_RAW
-    privileged: false
-    allowPrivilegeEscalation: false
-    defaultAllowPrivilegeEscalation: false
-    fsGroup:
-      rule: RunAsAny
-    runAsUser:
-      rule: MustRunAsNonRoot
-    seLinux:
-      rule: RunAsAny
-    supplementalGroups:
-      rule: RunAsAny
-    volumes:
-    - emptyDir
-    - secret
-    - persistentVolumeClaim
-    - downwardAPI
-    - configMap
-    - projected
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    name: psp:restricted
-  rules:
-  - apiGroups:
-    - extensions
-    resourceNames:
-    - restricted
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
-  ---
-  apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    name: psp:restricted
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: psp:restricted
-  subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:serviceaccounts
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:authenticated

--- a/ansible/roles/rke/templates/rancher-cluster.yml
+++ b/ansible/roles/rke/templates/rancher-cluster.yml
@@ -21,7 +21,6 @@ services:
       enabled: true
     event_rate_limit:
       enabled: true
-    pod_security_policy: true
     secrets_encryption_config:
       enabled: true
     service_node_port_range: 30000-32767

--- a/ansible/roles/rke/vars/main.yml
+++ b/ansible/roles/rke/vars/main.yml
@@ -1,6 +1,6 @@
 ---
-kubectl_version: v1.22.12
-helm_version: v3.9.3
+kubectl_version: v1.26.7
+helm_version: v3.12.3
 local_output_dir: "/tmp"
-rke_cli_version: "v{{ rke_version | default('1.3.12', true) }}"
+rke_cli_version: "v{{ rke_version | default('1.4.8', true) }}"
 tools_dir: "/home/{{ ansible_user_id }}/ranchhand/tools"

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -5,6 +5,7 @@ INSTANCE_NAME="${INSTANCE_NAME:-"ranchhand-local-$USER"}"
 INSTANCE_BLUEPRINT_ID="${INSTANCE_BLUEPRINT_ID:-ubuntu_16_04_2}"
 SSH_KEY_FILE="${SSH_KEY_FILE:-${HOME}/.ssh/id_rsa_a4d238e594137d6a2ec652c68f7f0e6b}"
 SSH_USER="${SSH_USER:-ubuntu}"
+export AWS_REGION="us-east-1"
 
 function setup_instance() {
   if [[ -n $INSTANCE_TAGS ]]; then


### PR DESCRIPTION
Version of RKE we're using has an unsafe bug: https://github.com/rancher/rke/pull/3033

This upgrades us past it, sets Rancher to the version we're using in the deployer (2.7.5) and upgrades a couple incidental things that just happened to be in the same files.

I upgraded to the newest RKE, which is compatible with 2.7.5, set this to use 2.7.5 (which the deployer is already overriding), and removed PSPs since the RKE component is now k8s 1.26.