### PR TITLE
PLAT-7422 - ssh argument fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
             -e 'cert_names=DNS:test.dominodatalab.com' \
             -e 'node_count=1' \
             --private-key=~/.ssh/id_rsa_a4d238e594137d6a2ec652c68f7f0e6b \
-            --ssh-common-args="-o StrictHostKeyChecking=no -o StrictHostKeyChecking=no -o ProxyCommand=\"ssh -o StrictHostKeyChecking=no -W %h:%p -q << parameters.ssh_user >>@$(cat instance-ip)\"" \
+            --ssh-common-args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand=\"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p -q << parameters.ssh_user >>@$(cat instance-ip)\"" \
             ansible/prod.yml --diff
     - run:
         name: Teardown test env

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+### Link to JIRA
+
+[PLAT-XYZ](https://dominodatalab.atlassian.net/browse/PLAT-XYZ)
+
+### What issue does this pull request solve?
+
+_placeholder_
+
+### What is the solution?
+
+_placeholder_
+
+### Testing
+_Briefly describe how the change was tested. The purpose of this section is that a reviewer can identify a test gap (if any)._
+
+_e.g. "I ran an upgrade from 5.7 to 5.8."_

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This tool aims to automate the steps listed in Rancher's official [HA Install][]
 This example shows a manual run of the production playbook (prod.yml) from a local machine imaging a cluster behind a bastion/proxy server.
 
 ```
-ansible-playbook -i '10.0.1.6,10.0.1.51,10.0.1.94,' --private-key=/Users/myhost/.ssh/id_rsa --user=ubuntu --ssh-common-args='-o StrictHostKeyChecking=no -o StrictHostKeyChecking=no -o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:%p -q ubuntu@54.190.1.95"' ansible/prod.yml --diff
+ansible-playbook -i '10.0.1.6,10.0.1.51,10.0.1.94,' --private-key=/Users/myhost/.ssh/id_rsa --user=ubuntu --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyCommand="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -W %h:%p -q ubuntu@54.190.1.95"' ansible/prod.yml --diff
 ```
 
 In the example above, only the bastion server, 54.190.1.95, is publicly accessible. However, including the Terraform module should be sufficient for most users.

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "null_resource" "ansible_playbook" {
         -i '${local.ip_addresses},' \
         --private-key=${var.ssh_key_path} \
         --user=${var.ssh_username} \
-        --ssh-common-args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${local.ansible_ssh_proxy}' \
+        --ssh-common-args='${local.ansible_ssh_proxy}' \
         -e 'cert_manager_version=${var.cert_manager_version}' \
         -e 'cert_names=${local.cert_names}' \
         -e '{"helm": { "host": "${var.helm_v3_registry_host}","user": "${var.helm_v3_registry_user}", "namespace": "${var.helm_v3_namespace}","password": "${var.helm_v3_registry_password}" }}' \

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -45,7 +45,7 @@ function setup_instance() {
   for retries in $(seq 0 ${max_retries}); do
     sleep 10
 
-    ssh -o StrictHostKeyChecking=no -i ${SSH_KEY_FILE} ${SSH_USER}@${ipaddr} exit && break || true
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${SSH_KEY_FILE} ${SSH_USER}@${ipaddr} exit && break || true
     echo "${ipaddr} ssh connection timeout. Sleeping for 10 seconds..."
   done
 


### PR DESCRIPTION
### Link to JIRA
[PLAT-7422](https://dominodatalab.atlassian.net/browse/PLAT-7422)

### What issue does this pull request solve?
We have a mixture of variable-driven and static arguments, leading (in some cases) to argument duplication. Also, it is recommended to (along with the strict host check override) pair a `/dev/null` knownhost file override to truly just accept the provided key and host, skipping the fingerprint check.

### What is the solution?
Choose either static or variable-driven (preferred) and remove the other. I chose to remove the static arguments causing duplication. For knownhost, provide `/dev/null` instead of actual file.

### Testing
This was tested in an install (`dc10623rci`) and an upgrade (`dclegg24311`) for 5.8.0.
