### PR TITLE
Don't use elb hostname for common name

### DIFF
--- a/ansible/roles/rke/tasks/ssl-certificates.yml
+++ b/ansible/roles/rke/tasks/ssl-certificates.yml
@@ -11,7 +11,7 @@
     module: openssl_csr
     path: "{{ local_output_dir }}/dominodatalab.com.csr"
     privatekey_path: "{{ local_output_dir }}/dominodatalab.com.pem"
-    common_name: "{{ cert_names.split(',')[0] | regex_replace('DNS:') }}"
+    common_name: "rancher.internal"
     subject_alt_name: "{{ cert_names }}"
     organization_name: Domino Data Lab, Inc.
     organizational_unit_name: Platform Engineering


### PR DESCRIPTION
Python cryptography is now enforcing the common name limit, so just leave it to the subject alt names only

See: https://github.com/pyca/cryptography/pull/11201