### PR TITLE
Fix kubectl download URL and add RHEL package support

### DIFF
--- a/ansible/roles/rke/tasks/main.yml
+++ b/ansible/roles/rke/tasks/main.yml
@@ -11,6 +11,14 @@
       - tar
   when: ansible_os_family == "Debian"
 
+- name: install yum packages
+  become: true
+  yum:
+    name:
+      - unzip
+      - tar
+  when: ansible_os_family == "RedHat"
+
 - name: Create RanchHand Directories
   file:
     path: "{{ item }}"
@@ -29,7 +37,7 @@
   retries: 10
   delay: 3
   with_items:
-    - "https://storage.googleapis.com/kubernetes-release/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+    - "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
     - "https://github.com/rancher/rke/releases/download/{{ rke_cli_version }}/rke_linux-amd64"
 
 - name: Download Packaged Binary Tools


### PR DESCRIPTION
## Fix kubectl download URL and add RHEL package support

### Changes

- **Update kubectl download URL** — Replace deprecated `storage.googleapis.com/kubernetes-release` with `dl.k8s.io` in the RKE ansible role. Newer kubectl versions (including v1.28.15) return 404 from the old Google Storage URL, breaking provisioning.

- **Add RHEL package installation** — Add a `yum` task for `unzip` and `tar` alongside the existing `apt` task, so the role works on both Debian and RedHat host families.

### Context

The Kubernetes project has been migrating release artifacts away from the Google-owned `gs://kubernetes-release` GCS bucket to the community-managed `dl.k8s.io` endpoint. Newer patch releases are no longer published to the old URL.

- kubernetes/k8s.io#2396 — Deprecate and migrate away from `gs://kubernetes-release`
- kubernetes/kubernetes#117949 — Replace `storage.googleapis.com/kubernetes-release` references with `dl.k8s.io`